### PR TITLE
[HOTFIX] Remove black transition on Tabs

### DIFF
--- a/src/components/Tabs/index.js
+++ b/src/components/Tabs/index.js
@@ -49,6 +49,9 @@ function Tabs({ activeTab, items, name: nameProp, ...props }) {
           <Tab
             key={label}
             label={label}
+            TabIndicatorProps={{
+              style: { transition: "none" },
+            }}
             onClick={
               href
                 ? (e) => {

--- a/src/components/Tabs/useStyles.js
+++ b/src/components/Tabs/useStyles.js
@@ -10,6 +10,7 @@ const useStyles = makeStyles(({ breakpoints, palette, typography }) => ({
   },
   indicator: {
     width: 0,
+    background: "transparent",
   },
   vertical: {
     background: "transparent",


### PR DESCRIPTION
## Description

Remove transition in Tabs when page is reloaded

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

Fix for this bug 👇🏽 

https://user-images.githubusercontent.com/3693563/144238760-49734bf6-1ff2-4079-beb8-ddb07356344c.mov


Fix 👇🏽 


https://user-images.githubusercontent.com/3693563/144240900-4cf6cfe3-16dd-4867-b800-4d6584718ad1.mov


## Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
