### PR TITLE
fetch when search or paginating

### DIFF
--- a/src/components/TweetsContainer/index.js
+++ b/src/components/TweetsContainer/index.js
@@ -116,7 +116,7 @@ function TweetsContainer({
   };
 
   const shouldFetch = () => {
-    if (!search) {
+    if (!(search || paginating)) {
       return null;
     }
 


### PR DESCRIPTION
## Description

Addresses the issue where pagination didn't trigger `fetch`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

![Peek 2021-12-14 17-22](https://user-images.githubusercontent.com/1779590/146016407-02e467af-6562-45c4-8e69-04602c2e6383.gif)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code

