### PR TITLE
[Fix] /explore/accounts settings

### DIFF
--- a/src/pages/explore/accounts.js
+++ b/src/pages/explore/accounts.js
@@ -5,6 +5,7 @@ import AccountsList from "@/twoopstracker/components/AccountsList";
 import Page from "@/twoopstracker/components/Page";
 import { pagination } from "@/twoopstracker/config";
 import { allAccounts } from "@/twoopstracker/lib";
+import { settings } from "@/twoopstracker/lib/cms";
 
 export default function Index(props) {
   return (
@@ -32,5 +33,11 @@ export async function getServerSideProps(context) {
   data.accounts = data?.results;
   delete data.results;
   // Pass data to the page via props
-  return { props: { data, session } };
+  return {
+    props: {
+      ...settings(),
+      data,
+      session,
+    },
+  };
 }


### PR DESCRIPTION
## Description

`settings` are missing in `/explore/accounts` page causing `Application error: a client-side exception has occurred (see the browser console for more information)`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

![Screenshot from 2022-01-11 11-28-18](https://user-images.githubusercontent.com/1779590/148907343-a8123c78-9fd3-4b2d-b7f1-b85c24e371cb.png)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code

