### PR TITLE
[Fix] CMS Content Loading

### DIFF
--- a/src/lib/cms.js
+++ b/src/lib/cms.js
@@ -7,7 +7,7 @@ import lexiconsContent from "@/cms/pages/lexicons.md";
 import footerContent from "@/cms/settings/footer.md";
 import navigationContent from "@/cms/settings/navigation.md";
 
-export function about() {
+function processAboutContent() {
   const { attributes } = aboutContent;
   attributes.partners =
     attributes.partners
@@ -17,11 +17,15 @@ export function about() {
         ...others,
       }))
       ?.map((partner) => md.renderObjectValuesInline(partner)) ?? null;
+}
+processAboutContent();
 
+export function about() {
+  const { attributes } = aboutContent;
   return attributes;
 }
 
-export function investigations() {
+function processInvestigationsContent() {
   const { attributes } = investigationsContent;
   attributes.reports =
     attributes.reports
@@ -33,11 +37,15 @@ export function investigations() {
         ...others,
       }))
       ?.map((i) => md.renderObjectValuesInline(i)) ?? null;
+}
+processInvestigationsContent();
 
+export function investigations() {
+  const { attributes } = investigationsContent;
   return attributes;
 }
 
-export function home() {
+function processHomeContent() {
   const { attributes } = homeContent;
   if (attributes.tool) {
     const { cta: buttonText, thumbnail: image, ...others } = attributes.tool;
@@ -72,11 +80,15 @@ export function home() {
       attributes.investigations.cta || null;
     attributes.investigations.cta = null;
   }
+}
+processHomeContent();
 
+export function home() {
+  const { attributes } = homeContent;
   return attributes;
 }
 
-export function lexicons() {
+function processLexiconsContent() {
   const { attributes } = lexiconsContent;
   attributes.resouces =
     attributes.resouces
@@ -87,11 +99,15 @@ export function lexicons() {
         ...others,
       }))
       ?.map((resource) => md.renderObjectValuesInline(resource)) ?? null;
+}
+processLexiconsContent();
 
+export function lexicons() {
+  const { attributes } = lexiconsContent;
   return attributes;
 }
 
-export function footer() {
+function processFooterContent() {
   const { attributes } = footerContent;
   const {
     description,
@@ -123,10 +139,15 @@ export function footer() {
 
   return attributes;
 }
+processFooterContent();
+
+export function footer() {
+  const { attributes } = footerContent;
+  return attributes;
+}
 
 export function navigation() {
   const { attributes } = navigationContent;
-
   return attributes;
 }
 


### PR DESCRIPTION
## Description

Since cms lib exported function to process content and these function modified the content in place, multiple calls to these functions sometimes resulted in 2nd call working on already modified content.

This PR ensures all cms content is processed first on first import and all exported functions are basically just getters i.e. don't modify content.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

![S](https://user-images.githubusercontent.com/1779590/148932421-7d776402-8a16-42aa-b6ed-c1a13b91f720.png)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas

