### PR TITLE
[Fix] Add box-shadow to images on Investigate Section

### DIFF
--- a/src/components/InvestigationsPreview/index.js
+++ b/src/components/InvestigationsPreview/index.js
@@ -20,6 +20,11 @@ const useStyles = makeStyles(({ typography, palette }) => ({
     paddingTop: typography.pxToRem(113),
     paddingBottom: typography.pxToRem(123),
   },
+  image: {
+    "& span": {
+      boxShadow: `0 4px 8px 0 rgba(0,0,0,0.4)`,
+    },
+  },
   description: {
     marginTop: typography.pxToRem(39),
     marginBottom: typography.pxToRem(80),
@@ -60,13 +65,15 @@ function InvestigationsPreview({
           {items.slice(0, 4).map(({ href, image, title: bookTitle }) => (
             <Grid item xs={6} md={3}>
               <Link href={href}>
-                <Image
-                  height={369}
-                  width={297}
-                  objectFit="contain"
-                  src={image}
-                  alt={bookTitle}
-                />
+                <div className={classes.image}>
+                  <Image
+                    height={369}
+                    width={297}
+                    objectFit="contain"
+                    src={image}
+                    alt={bookTitle}
+                  />
+                </div>
                 <Typography
                   className={classes.investigationtitle}
                   variant="body1"


### PR DESCRIPTION
## Description

Add drop shadows under the images on Investigation section on home page as in [Figma](https://www.figma.com/proto/jOJf828aks26pasSL15AuV/CfA-Troll-Tracker-%7C-Working?node-id=1737%3A31878&scaling=min-zoom&page-id=1737%3A31877&starting-point-node-id=1737%3A31878)

Link to [Trello](https://trello.com/c/7r7RBZyC/13-no-dropshadow-under-the-images)
Link to [Pivotal](https://www.pivotaltracker.com/story/show/180932631)

## Type of change

Please delete options that are not relevant.

- [ ] Chore (non-breaking change which does not add visible functionality but improves code quality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots

### Application:
<img width="1308" alt="Screenshot 2022-01-18 at 10 29 25" src="https://user-images.githubusercontent.com/12892109/149890729-636659fe-a77e-4a29-900c-cac1a8e4eb4d.png">

### Figma:
<img width="883" alt="Screenshot 2022-01-18 at 10 29 58" src="https://user-images.githubusercontent.com/12892109/149890752-7dd0a80b-1407-4108-adc1-3cdfc3b41e6b.png">


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
