### PR TITLE
[Fix] Text Indentation 

### DIFF
--- a/src/components/Hero/index.js
+++ b/src/components/Hero/index.js
@@ -35,6 +35,9 @@ const useStyles = makeStyles(({ breakpoints, typography, palette }) => ({
     [breakpoints.up("lg")]: {
       width: typography.pxToRem(732),
     },
+    [breakpoints.up("xl")]: {
+      width: typography.pxToRem(1077),
+    },
   },
   description: {
     color: palette.text.secondary,
@@ -42,7 +45,7 @@ const useStyles = makeStyles(({ breakpoints, typography, palette }) => ({
     maxWidth: "70%",
     [breakpoints.up("lg")]: {
       marginTop: typography.pxToRem(80),
-      width: typography.pxToRem(732),
+      width: typography.pxToRem(966),
     },
   },
   section: {

--- a/src/components/Hero/index.js
+++ b/src/components/Hero/index.js
@@ -39,6 +39,7 @@ const useStyles = makeStyles(({ breakpoints, typography, palette }) => ({
   description: {
     color: palette.text.secondary,
     marginTop: typography.pxToRem(40),
+    maxWidth: "70%",
     [breakpoints.up("lg")]: {
       marginTop: typography.pxToRem(80),
       width: typography.pxToRem(732),

--- a/src/components/InvestigationsPreview/index.js
+++ b/src/components/InvestigationsPreview/index.js
@@ -37,6 +37,7 @@ const useStyles = makeStyles(({ breakpoints, typography, palette }) => ({
     marginBottom: typography.pxToRem(80),
     color: palette.text.secondary,
     fontWeight: 400,
+    maxWidth: "90%",
   },
   investigationtitle: {
     color: palette.text.secondary,

--- a/src/components/InvestigationsPreview/index.js
+++ b/src/components/InvestigationsPreview/index.js
@@ -37,7 +37,12 @@ const useStyles = makeStyles(({ breakpoints, typography, palette }) => ({
     marginBottom: typography.pxToRem(80),
     color: palette.text.secondary,
     fontWeight: 400,
-    maxWidth: "90%",
+    [breakpoints.up("lg")]: {
+      width: typography.pxToRem(1053),
+    },
+    [breakpoints.up("xl")]: {
+      width: typography.pxToRem(1530),
+    },
   },
   investigationtitle: {
     color: palette.text.secondary,


### PR DESCRIPTION
## Description

Could the header text on About, Investigations and Lexicons pages on md screens be indented from the right side so that there are more words on the second line and easier to read and also so that the white text doesn't overlap the white part of the background image.

Link to [Pivotal](https://www.pivotaltracker.com/story/show/180934473)

## Type of change

Please delete options that are not relevant.

- [ ] Chore (non-breaking change which does not add visible functionality but improves code quality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots

<img width="878" alt="Screenshot 2022-01-24 at 20 35 50" src="https://user-images.githubusercontent.com/12892109/150835266-2c5da039-5dbe-49a0-b4ee-7960289d59cf.png">
<img width="868" alt="Screenshot 2022-01-24 at 20 36 02" src="https://user-images.githubusercontent.com/12892109/150835285-047e7270-b837-46e2-9b26-e03964507bf6.png">
<img width="877" alt="Screenshot 2022-01-24 at 20 39 56" src="https://user-images.githubusercontent.com/12892109/150835422-bf558fd8-2426-417e-9f58-264f37c0a645.png">


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
