### PR TITLE
[Fix] Align Items in Footer to The Left

### DIFF
--- a/src/components/Footer/index.js
+++ b/src/components/Footer/index.js
@@ -65,6 +65,7 @@ function Footer({
                   link: classes.stayInTouchLink,
                   links: classes.stayInTouchLinks,
                   text: classes.stayInTouchText,
+                  title: classes.stayInTouchTitle,
                 }}
               />
             )}

--- a/src/components/Footer/useStyles.js
+++ b/src/components/Footer/useStyles.js
@@ -60,6 +60,9 @@ const useStyles = makeStyles(({ breakpoints, palette, typography }) => ({
       lineHeight: 20.93 / 14,
     },
   },
+  stayInTouchTitle: {
+    textAlign: "left",
+  },
   stayInTouchLink: {
     padding: 0,
   },

--- a/src/components/Footer/useStyles.js
+++ b/src/components/Footer/useStyles.js
@@ -31,10 +31,10 @@ const useStyles = makeStyles(({ breakpoints, palette, typography }) => ({
   stayInTouch: {
     display: "flex",
     flexDirection: "column",
-    alignItems: "center",
     letterspacing: typography.pxToRem(0.7),
     [breakpoints.up("lg")]: {
       flexDirection: "row",
+      alignItems: "center",
     },
   },
   stayInTouchIcon: {
@@ -51,7 +51,7 @@ const useStyles = makeStyles(({ breakpoints, palette, typography }) => ({
     fontSize: typography.pxToRem(10.48),
     lineHeight: 15.67 / 10.48,
     margin: 0,
-    padding: `${typography.pxToRem(10)} ${typography.pxToRem(8)}`,
+    padding: `${typography.pxToRem(10)} ${typography.pxToRem(0)}`,
     [breakpoints.up("lg")]: {
       padding: 0,
     },
@@ -64,10 +64,8 @@ const useStyles = makeStyles(({ breakpoints, palette, typography }) => ({
     padding: 0,
   },
   stayInTouchLinks: {
-    justifyContent: "center",
-    marginLeft: typography.pxToRem(21.84),
-    [breakpoints.up("xl")]: {
-      marginLeft: typography.pxToRem(29),
+    [breakpoints.up("lg")]: {
+      marginLeft: typography.pxToRem(21.84),
     },
     "& > a": {
       borderRight: "none",
@@ -87,7 +85,6 @@ const useStyles = makeStyles(({ breakpoints, palette, typography }) => ({
     },
   },
   quickLinkRoot: {
-    textAlign: "center",
     padding: `${typography.pxToRem(32)} 0 `,
     [breakpoints.up("lg")]: {
       textAlign: "inherit",

--- a/src/components/Footer/useStyles.js
+++ b/src/components/Footer/useStyles.js
@@ -67,6 +67,9 @@ const useStyles = makeStyles(({ breakpoints, palette, typography }) => ({
     [breakpoints.up("lg")]: {
       marginLeft: typography.pxToRem(21.84),
     },
+    [breakpoints.up("xl")]: {
+      marginLeft: typography.pxToRem(29),
+    },
     "& > a": {
       borderRight: "none",
       display: "flex",


### PR DESCRIPTION
## Description

Align Resources, About This project and Stay In Touch to the left side. 

[Pivotal](https://www.pivotaltracker.com/story/show/180932745)

## Type of change

Please delete options that are not relevant.

- [ ] Chore (non-breaking change which does not add visible functionality but improves code quality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots
<img width="388" alt="Screenshot 2022-01-31 at 08 55 58" src="https://user-images.githubusercontent.com/12892109/151747684-2578fcaa-6c09-444b-a07a-5290bf0af37f.png">
<img width="1437" alt="Screenshot 2022-01-31 at 09 08 04" src="https://user-images.githubusercontent.com/12892109/151747688-e37866c0-9bc0-4146-b845-c031bad3ee09.png">


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
