### PR TITLE
[Feature] Accounts lists sorting

### DIFF
--- a/src/components/ContentActions/index.js
+++ b/src/components/ContentActions/index.js
@@ -57,11 +57,18 @@ const useStyles = makeStyles(({ palette, typography, breakpoints }) => ({
       flexDirection: "row",
     },
   },
+  otherActions: {
+    flexDirection: "column",
+    [breakpoints.up("md")]: {
+      flexDirection: "row",
+    },
+  },
 }));
 
 const ContentActions = forwardRef(function ContentActions(props, ref) {
   const {
     apiUri,
+    children,
     className,
     menuItems,
     onChangeSortBy,
@@ -139,7 +146,7 @@ const ContentActions = forwardRef(function ContentActions(props, ref) {
           <Grid
             item
             xs={12}
-            md={8}
+            md={4}
             container
             justifyContent="flex-end"
             className={classes.sortAction}
@@ -156,6 +163,18 @@ const ContentActions = forwardRef(function ContentActions(props, ref) {
               />
             </Grid>
           </Grid>
+          {children ? (
+            <Grid
+              item
+              xs={12}
+              md={4}
+              container
+              justifyContent="flex-end"
+              className={classes.otherActions}
+            >
+              <Grid item>{children}</Grid>
+            </Grid>
+          ) : null}
         </Grid>
       </Section>
     </div>
@@ -164,6 +183,7 @@ const ContentActions = forwardRef(function ContentActions(props, ref) {
 
 ContentActions.propTypes = {
   apiUri: PropTypes.string,
+  children: PropTypes.node,
   className: PropTypes.string,
   menuItems: PropTypes.arrayOf(
     PropTypes.shape({
@@ -180,6 +200,7 @@ ContentActions.propTypes = {
 
 ContentActions.defaultProps = {
   apiUri: undefined,
+  children: undefined,
   className: PropTypes.string,
   menuItems: undefined,
   onChangeSortBy: undefined,

--- a/src/components/Lists/index.js
+++ b/src/components/Lists/index.js
@@ -157,33 +157,35 @@ function Lists({
   };
 
   const count = Math.ceil((lists?.count ?? 0) / pageSize);
+  const newList = (
+    <div className={classes.createListModal}>
+      <Typography onClick={handleOpen} className={classes.create}>
+        Create New List
+      </Typography>
+      <ListModal
+        open={open}
+        onClose={handleClose}
+        nameValue={name}
+        nameLabel="ListName"
+        nameHelper="Name of List"
+        nameOnChange={handleChange}
+        accountsLabel="User Accounts"
+        accountsOnChange={handleChange}
+        accountsHelper="Enter twitter account names seperated by a comma i.e userone,usertwo"
+        privacyOnChange={handleChange}
+        accountsValue={accounts}
+        privacyValue={privacy}
+        buttonLabel="Create"
+        buttonOnClick={onCreate}
+      />
+    </div>
+  );
   return (
     <div className={classes.root}>
       <div className={classes.section}>
         <Typography variant="h2" className={classes.title}>
           Your Lists
         </Typography>
-        <div className={classes.createListModal}>
-          <Typography onClick={handleOpen} className={classes.create}>
-            Create New List
-          </Typography>
-          <ListModal
-            open={open}
-            onClose={handleClose}
-            nameValue={name}
-            nameLabel="ListName"
-            nameHelper="Name of List"
-            nameOnChange={handleChange}
-            accountsLabel="User Accounts"
-            accountsOnChange={handleChange}
-            accountsHelper="Enter twitter account names seperated by a comma i.e userone,usertwo"
-            privacyOnChange={handleChange}
-            accountsValue={accounts}
-            privacyValue={privacy}
-            buttonLabel="Create"
-            buttonOnClick={onCreate}
-          />
-        </div>
         {lists?.count ? (
           <>
             <ContentActions
@@ -196,8 +198,15 @@ function Lists({
               onClickSortOrder={handleClickSortOrder}
               sort={sort}
               type="lists"
-              classes={{ section: classes.actions }}
-            />
+              classes={{
+                section: classes.actions,
+                downloadAction: classes.downloadAction,
+                sortAction: classes.sortAction,
+                otherActions: classes.otherActions,
+              }}
+            >
+              {newList}
+            </ContentActions>
             <Grid container>
               {lists?.results?.map((item) => (
                 <Grid item xs={12}>
@@ -221,7 +230,10 @@ function Lists({
             />
           </>
         ) : (
-          <Typography variant="body1">There are no lists</Typography>
+          <div className={classes.noLists}>
+            {newList}
+            <Typography variant="body1">There are no lists</Typography>
+          </div>
         )}
       </div>
     </div>

--- a/src/components/Lists/index.js
+++ b/src/components/Lists/index.js
@@ -34,7 +34,7 @@ function Lists({
   const [page, setPage] = useState(parseInt(pageProp, 10) || 1);
   // Changes which page is displayed when either page or sort is changed.
   const [paginating, setPaginating] = useState(false);
-  const [pageSize, setPageSize] = useState(parseInt(pageSizeProp, 10) || 10);
+  const [pageSize, setPageSize] = useState(parseInt(pageSizeProp, 10) || 20);
   const handleOpen = () => setOpen(true);
   const handleClose = () => setOpen(false);
   const classes = useStyles(props);

--- a/src/components/Lists/useStyles.js
+++ b/src/components/Lists/useStyles.js
@@ -10,16 +10,7 @@ const useStyles = makeStyles(({ typography, palette, breakpoints }) => ({
       justifyContent: "space-between",
     },
   },
-  createListModal: {
-    display: "flex",
-    flexDirection: "column",
-    justifyContent: "flex-start",
-    alignItems: "flex-start",
-    [breakpoints.up("md")]: {
-      justifyContent: "flex-end",
-      alignItems: "flex-end",
-    },
-  },
+  createListModal: {},
   listItem: {
     marginTop: typography.pxToRem(20),
   },
@@ -30,11 +21,6 @@ const useStyles = makeStyles(({ typography, palette, breakpoints }) => ({
     cursor: "pointer",
     color: palette.primary.main,
     textDecoration: "underline",
-    padding: `${typography.pxToRem(20)} 0`,
-    [breakpoints.up("md")]: {
-      position: "relative",
-      top: typography.pxToRem(60),
-    },
   },
   label: {
     color: "#000",
@@ -51,6 +37,33 @@ const useStyles = makeStyles(({ typography, palette, breakpoints }) => ({
   },
   actions: {
     width: "100%",
+  },
+  downloadAction: {
+    order: 1,
+    [breakpoints.up("md")]: {
+      order: 0,
+    },
+  },
+  sortAction: {
+    order: 2,
+    [breakpoints.up("md")]: {
+      order: 0,
+    },
+  },
+  otherActions: {
+    order: 0,
+    [breakpoints.up("md")]: {
+      order: 2,
+    },
+  },
+  noLists: {
+    paddingTop: typography.pxToRem(42),
+    [breakpoints.up("md")]: {
+      paddingTop: typography.pxToRem(72),
+    },
+    [breakpoints.up("xl")]: {
+      paddingTop: typography.pxToRem(80),
+    },
   },
 }));
 

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -141,16 +141,10 @@ export const upload = {
   uploadLabel: "Select a File",
 };
 
-export const searchPagination = {
-  pageSizeDefaultValue: "3",
+export const paginationOptions = {
+  pageSizeDefaultValue: 20,
   pageSizeLabel: "Results on Page",
-  pageSizeOptions: [{ value: "10" }, { value: "20" }],
-};
-
-export const listPagination = {
-  pageSizeDefaultValue: "3",
-  pageSizeLabel: "Results on Page",
-  pageSizeOptions: [{ value: "10" }, { value: "20" }],
+  pageSizeOptions: [{ value: 20 }, { value: 50 }],
 };
 
 export const accounts = {

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -4,21 +4,38 @@ import fetchJson from "@/twoopstracker/utils/fetchJson";
 
 const BASE_URL = process.env.NEXT_PUBLIC_TWOOPSTRACKER_API_URL;
 
-export async function lists(session, pageData) {
-  const listParams = new URLSearchParams();
-
-  if (pageData.page) {
-    listParams.append("page", pageData.page);
+export async function lists(session, { download, page, pageSize, sort }) {
+  const searchParams = new URLSearchParams();
+  if (download) {
+    searchParams.append("download", download);
   }
-  if (pageData.pageSize) {
-    listParams.append("page_size", pageData.pageSize);
+  if (page) {
+    searchParams.append("page", page);
   }
-  if (pageData.download) {
-    listParams.append("download", pageData.download);
+  if (pageSize) {
+    searchParams.append("page_size", pageSize);
+  }
+  if (sort) {
+    let sortBy;
+    switch (sort.replace(/^-/, "")) {
+      case "created-at":
+        sortBy = "created_at";
+        break;
+      case "name":
+        sortBy = "name";
+        break;
+      default:
+        sortBy = null;
+        break;
+    }
+    if (sortBy) {
+      const sortOrder = sort.startsWith("-") ? "-" : "";
+      searchParams.append("ordering", `${sortOrder}${sortBy}`);
+    }
   }
 
   const result = await fetchJson(
-    `${BASE_URL}/lists/?${listParams.toString()}`,
+    `${BASE_URL}/lists/?${searchParams.toString()}`,
     session
   );
   return result;

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -4,7 +4,7 @@ import fetchJson from "@/twoopstracker/utils/fetchJson";
 
 const BASE_URL = process.env.NEXT_PUBLIC_TWOOPSTRACKER_API_URL;
 
-export async function lists(session, { download, page, pageSize, sort }) {
+export async function lists({ download, page, pageSize, sort }, session) {
   const searchParams = new URLSearchParams();
   if (download) {
     searchParams.append("download", download);

--- a/src/pages/account/[[...slug]].js
+++ b/src/pages/account/[[...slug]].js
@@ -10,11 +10,7 @@ import Tabs from "@/twoopstracker/components/Tabs";
 import Upload from "@/twoopstracker/components/Upload";
 import UserAccount from "@/twoopstracker/components/UserAccount";
 import UserSearch from "@/twoopstracker/components/UserSearch";
-import {
-  searchPagination,
-  upload,
-  listPagination,
-} from "@/twoopstracker/config";
+import { upload, paginationOptions } from "@/twoopstracker/config";
 import { lists, getSavedSearches } from "@/twoopstracker/lib";
 import { settings } from "@/twoopstracker/lib/cms";
 
@@ -53,14 +49,14 @@ function Account({ lists: listsProp, activeSlug, searches, ...props }) {
         children = (
           <Lists
             lists={listsProp}
-            paginationProps={listPagination}
+            paginationProps={paginationOptions}
             {...props}
           />
         );
         break;
       case "searches":
         children = (
-          <UserSearch searches={searches} paginationProps={searchPagination} />
+          <UserSearch searches={searches} paginationProps={paginationOptions} />
         );
         break;
       case "data":
@@ -117,8 +113,8 @@ export async function getServerSideProps(context) {
   const [activeSlug] = params?.slug ?? ["lists"];
   const activePageTitle = accountPages[activeSlug]?.label ?? "Account";
   const title = `${activePageTitle}${userName ? ` | ${userName}` : ""}`;
-  const foundLists = await lists(session, { pageSize: 5 });
-  const searches = await getSavedSearches({ pageSize: 3 }, session);
+  const foundLists = await lists(session, { pageSize: 20 });
+  const searches = await getSavedSearches({ pageSize: 20 }, session);
 
   const { query: userQuery } = context;
   const query = {

--- a/src/pages/account/[[...slug]].js
+++ b/src/pages/account/[[...slug]].js
@@ -109,17 +109,20 @@ export async function getServerSideProps(context) {
     };
   }
 
+  const { query: userQuery } = context;
+  const { page = 1, pageSize = 20, sort = "name" } = userQuery;
   const userName = session?.user?.name;
   const [activeSlug] = params?.slug ?? ["lists"];
   const activePageTitle = accountPages[activeSlug]?.label ?? "Account";
   const title = `${activePageTitle}${userName ? ` | ${userName}` : ""}`;
-  const foundLists = await lists(session, { pageSize: 20 });
-  const searches = await getSavedSearches({ pageSize: 20 }, session);
+  const foundLists = await lists({ page, pageSize, sort }, session);
+  const searches = await getSavedSearches({ page, pageSize }, session);
 
-  const { query: userQuery } = context;
   const query = {
-    sort: activeSlug === "lists" ? "name" : null,
     ...userQuery,
+    sort: activeSlug === "lists" ? sort : null,
+    page: ["lists", "searches"].includes(activeSlug) ? page : null,
+    pageSize: ["lists", "searches"].includes(activeSlug) ? pageSize : null,
   };
 
   return {

--- a/src/pages/api/lists/index.js
+++ b/src/pages/api/lists/index.js
@@ -6,7 +6,7 @@ export default async function handler(req, res) {
   const session = await getSession({ req });
 
   if (req.method === "GET") {
-    const results = await lists(session, req.query);
+    const results = await lists(req.query, session);
     return res.status(200).json(results);
   }
 


### PR DESCRIPTION
## Description

This PR allows users to sort the accounts lists:

 - [x] By list name, and
 - [x] By list creation timestamp.

This is of course, in both ASC and DESC order.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Screenshots

![Peek 2022-02-01 09-53](https://user-images.githubusercontent.com/1779590/151925312-83bc7ab1-4e09-404d-abf2-bb8fe0520fce.gif)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas

