### PR TITLE
[Feat] `profile_image_url_https`

### DIFF
--- a/src/components/Account/index.js
+++ b/src/components/Account/index.js
@@ -16,7 +16,8 @@ function Account({
     screen_name: screenName,
     created_at: createdAt,
     protected: accountType,
-    profile_image_url: image,
+    profile_image_url: profileImageHttpNormal,
+    profile_image_url_https: profileImageHttpsNormal,
   },
   items,
   onDelete,
@@ -29,7 +30,8 @@ function Account({
   const classes = useStyles(props);
 
   const date = new Date(createdAt);
-  const profileImage = image?.replace("_normal", "");
+  const profileImageNormal = profileImageHttpsNormal || profileImageHttpNormal;
+  const profileImage = profileImageNormal?.replace("_normal", "");
 
   const onAccountDelete = async () => {
     try {
@@ -102,6 +104,7 @@ Account.propTypes = {
     screen_name: PropTypes.string,
     created_at: PropTypes.string,
     profile_image_url: PropTypes.string,
+    profile_image_url_https: PropTypes.string,
     protected: PropTypes.bool,
   }),
   items: PropTypes.number,

--- a/src/components/TweetCard/index.js
+++ b/src/components/TweetCard/index.js
@@ -39,9 +39,11 @@ function TweetCard({
     name,
     screen_name: screenName,
     protected: accountStatus,
-    profile_image_url: profileImageNormal,
+    profile_image_url: profileImageHttpNormal,
+    profile_image_url_https: profileImageHttpsNormal,
   } = owner;
 
+  const profileImageNormal = profileImageHttpsNormal || profileImageHttpNormal;
   // NOTE(kilemensi): Since our card size is bigger than _bigger size from
   //                  alternative size offered by Twitter, we need to use
   //                  original size if avaiable.
@@ -160,6 +162,7 @@ TweetCard.propTypes = {
     name: PropTypes.string,
     protected: PropTypes.bool,
     profile_image_url: PropTypes.string,
+    profile_image_url_https: PropTypes.string,
   }),
   results: PropTypes.arrayOf(PropTypes.shape({})),
   onClick: PropTypes.func,

--- a/src/components/Tweets/index.stories.js
+++ b/src/components/Tweets/index.stories.js
@@ -62,7 +62,7 @@ const tweets = [
       friends_count: 3144,
       favourites_count: 3213,
       statuses_count: 3213,
-      profile_image_url:
+      profile_image_url_https:
         "https://pbs.twimg.com/profile_images/1096380175791607808/0OVjpWb8_normal.png",
       deleted: false,
     },


### PR DESCRIPTION
## Description

This PR prioritises loading profile images from `profile_image_url_https` over `profile_image_url`. See https://github.com/CodeForAfrica/TwoopsTracker/pull/55 for background.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Screenshots

N/A

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code

